### PR TITLE
Fix: Update to Android SDK 36 and resolve build issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 34
-    buildToolsVersion "34.0.0"
+    compileSdk 36
+    buildToolsVersion "36.0.0"
     buildFeatures {
         buildConfig true
     }
     defaultConfig {
         applicationId "me.ghui.v2er"
         minSdkVersion 27
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode rootProject.ext.app.versionCode
         versionName rootProject.ext.app.versionName
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/java/me/ghui/v2er/widget/richtext/GlideImageGetter.java
+++ b/app/src/main/java/me/ghui/v2er/widget/richtext/GlideImageGetter.java
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.graphics.drawable.DrawableWrapperCompat;
+import androidx.appcompat.graphics.drawable.DrawableWrapper;
 import android.text.Html;
 import android.widget.TextView;
 
@@ -77,19 +77,19 @@ public class GlideImageGetter implements Html.ImageGetter, Drawable.Callback {
 
     private class WrapperTarget extends SimpleTarget<Drawable> {
         private int mMaxWidth;
-        private DrawableWrapperCompat wrapperDrawable;
+        private DrawableWrapper wrapperDrawable;
 
         @SuppressLint("RestrictedApi")
         public WrapperTarget(int maxWidth) {
             //这里只缩小不放大
             super(maxWidth, TexureUtil.fitMaxHeight());
             this.mMaxWidth = maxWidth;
-            wrapperDrawable = new DrawableWrapperCompat(null);
+            wrapperDrawable = new DrawableWrapper(null);
             wrapperDrawable.setCallback(GlideImageGetter.this);
             updateWrapperedDrawable(mLoadingDrawable);
         }
 
-        public DrawableWrapperCompat getWrapperDrawable() {
+        public DrawableWrapper getWrapperDrawable() {
             return wrapperDrawable;
         }
 


### PR DESCRIPTION
## Summary
- Updated the project to use Android SDK 36 (Android 15) to match local SDK installation
- Fixed DrawableWrapper compatibility issues that were causing build failures
- Resolved compilation errors to ensure the app builds successfully

## Changes
1. **SDK Version Updates**:
   - Updated `compileSdk` from 34 to 36
   - Updated `targetSdk` from 34 to 36  
   - Updated `buildToolsVersion` to 36.0.0

2. **Fixed DrawableWrapper Import**:
   - The `DrawableWrapperCompat` class was removed in newer AndroidX versions
   - Reverted to using the original `DrawableWrapper` from `androidx.appcompat.graphics.drawable`
   - This fixes the compilation error in `GlideImageGetter.java`

## Test Plan
- [x] Successfully built debug APK locally
- [x] Installed and launched app on Pixel 8 device (Android 15)
- [x] Verified app functionality works as expected

## Notes
These changes allow developers with newer Android SDK installations to build the project without having to downgrade their SDK tools.

🤖 Generated with [Claude Code](https://claude.ai/code)