### PR TITLE
Add manual triggering options for Claude code review

### DIFF
--- a/.github/workflows/claude-code-review-manual.yml
+++ b/.github/workflows/claude-code-review-manual.yml
@@ -1,0 +1,50 @@
+name: Claude Code Review (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to review'
+        required: true
+        type: number
+      review_type:
+        description: 'Type of review to perform'
+        required: false
+        default: 'standard'
+        type: choice
+        options:
+          - standard
+          - security-focused
+          - performance-focused
+          - quick-check
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/merge
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          
+          # Customize prompt based on review type
+          direct_prompt: |
+            Please review PR #${{ inputs.pr_number }} with focus on:
+            ${{ inputs.review_type == 'security-focused' && '- Security vulnerabilities and best practices' || 
+                inputs.review_type == 'performance-focused' && '- Performance optimizations and bottlenecks' ||
+                inputs.review_type == 'quick-check' && '- Critical issues and bugs only (brief review)' ||
+                '- Code quality, bugs, performance, security, and test coverage' }}
+            
+            Be constructive and helpful in your feedback.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,21 +2,24 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, synchronize, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to review (leave empty for current PR)'
+        required: false
+        type: string
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run if:
+    # 1. Manually triggered via workflow_dispatch
+    # 2. PR has the 'claude-review' label
+    # 3. PR is from a first-time contributor (automatic)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'claude-review') ||
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Modified claude-code-review.yml to support both manual and automatic triggering
- Added label-based triggering using 'claude-review' label
- Created dedicated manual review workflow with customizable review types

## Changes
1. **Label-based triggering**: Add 'claude-review' label to any PR to trigger review
2. **Manual workflow dispatch**: Can manually trigger from Actions tab
3. **Automatic review**: Only runs automatically for first-time contributors
4. **Dedicated manual workflow**: New workflow file for pure manual reviews with PR number input

## Test plan
- [ ] Create this PR without the 'claude-review' label - review should NOT run
- [ ] Add 'claude-review' label - review should trigger
- [ ] Test manual trigger from Actions tab
- [ ] Verify first-time contributor PRs still get automatic review

🤖 Generated with [Claude Code](https://claude.ai/code)