### PR TITLE
fix: Fix release signing configuration for CI/CD

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,13 +29,16 @@ android {
                 storePassword GHUI_KEYSTORE_PASSWORD
                 keyAlias project.hasProperty("GHUI_KEY_ALIAS") ? GHUI_KEY_ALIAS : "ghui"
                 keyPassword GHUI_KEY_PASSWORD
+            } else if (project.hasProperty("GHUI_KEYSTORE_PASSWORD") && project.hasProperty("GHUI_KEY_PASSWORD")) {
+                // CI/CD environment but keystore file might not exist yet
+                // This prevents the build from failing during configuration phase
+                storeFile file("keystore.jks")
+                storePassword GHUI_KEYSTORE_PASSWORD
+                keyAlias project.hasProperty("GHUI_KEY_ALIAS") ? GHUI_KEY_ALIAS : "ghui"
+                keyPassword GHUI_KEY_PASSWORD
             } else {
-                // For local builds without proper signing setup, use debug signing
-                def debugSigningConfig = android.signingConfigs.debug
-                storeFile debugSigningConfig.storeFile
-                storePassword debugSigningConfig.storePassword
-                keyAlias debugSigningConfig.keyAlias
-                keyPassword debugSigningConfig.keyPassword
+                // For local builds without proper signing setup, throw an error
+                throw new GradleException("Release builds require signing configuration. Please provide GHUI_KEYSTORE_PASSWORD and GHUI_KEY_PASSWORD.")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix the release build failure caused by incorrect keystore configuration
- Remove fallback to debug keystore that was causing "debug.keystore not found" error

## Problem
The release workflow was failing with:
```
Keystore file '/home/runner/.config/.android/debug.keystore' not found for signing config 'release'.
```

## Solution
- Added proper handling for CI/CD environment where keystore is created dynamically
- Removed the fallback to debug signing config which was causing the error
- Added explicit error message for local release builds without proper signing setup

## Test Plan
- [x] Tested the configuration logic
- [ ] Release workflow should now properly use the keystore created from KEYSTORE_BASE64 secret

🤖 Generated with [Claude Code](https://claude.ai/code)