### PR TITLE
fix: Use environment variables for CI/CD signing configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,13 +29,13 @@ android {
                 storePassword GHUI_KEYSTORE_PASSWORD
                 keyAlias project.hasProperty("GHUI_KEY_ALIAS") ? GHUI_KEY_ALIAS : "ghui"
                 keyPassword GHUI_KEY_PASSWORD
-            } else if (project.hasProperty("GHUI_KEYSTORE_PASSWORD") && project.hasProperty("GHUI_KEY_PASSWORD")) {
+            } else if (System.getenv("GHUI_KEYSTORE_PASSWORD") != null && System.getenv("GHUI_KEY_PASSWORD") != null) {
                 // CI/CD environment but keystore file might not exist yet
                 // This prevents the build from failing during configuration phase
                 storeFile file("keystore.jks")
-                storePassword GHUI_KEYSTORE_PASSWORD
-                keyAlias project.hasProperty("GHUI_KEY_ALIAS") ? GHUI_KEY_ALIAS : "ghui"
-                keyPassword GHUI_KEY_PASSWORD
+                storePassword System.getenv("GHUI_KEYSTORE_PASSWORD")
+                keyAlias System.getenv("GHUI_KEY_ALIAS") ?: "ghui"
+                keyPassword System.getenv("GHUI_KEY_PASSWORD")
             } else {
                 // For local builds without proper signing setup, throw an error
                 throw new GradleException("Release builds require signing configuration. Please provide GHUI_KEYSTORE_PASSWORD and GHUI_KEY_PASSWORD.")


### PR DESCRIPTION
## Summary
- Fixed the release workflow failure by properly reading environment variables in build.gradle
- Changed from `project.hasProperty()` to `System.getenv()` for CI/CD environment detection
- GitHub Actions passes secrets as environment variables, not Gradle properties

## Context
The release workflow was failing with:
```
Release builds require signing configuration. Please provide GHUI_KEYSTORE_PASSWORD and GHUI_KEY_PASSWORD.
```

This was because the build.gradle was checking for Gradle properties, but GitHub Actions sets environment variables.

## Test Plan
- [ ] CI workflow should pass and build signed APKs
- [ ] Release workflow should successfully create releases
- [ ] Local builds should still work as before

🤖 Generated with [Claude Code](https://claude.ai/code)