### PR TITLE
fix: Handle empty GHUI_KEY_ALIAS environment variable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
                 // This prevents the build from failing during configuration phase
                 storeFile file("keystore.jks")
                 storePassword System.getenv("GHUI_KEYSTORE_PASSWORD")
-                keyAlias System.getenv("GHUI_KEY_ALIAS") ?: "ghui"
+                keyAlias (System.getenv("GHUI_KEY_ALIAS") ?: "").trim().isEmpty() ? "ghui" : System.getenv("GHUI_KEY_ALIAS")
                 keyPassword System.getenv("GHUI_KEY_PASSWORD")
             } else {
                 // For local builds without proper signing setup, throw an error


### PR DESCRIPTION
## Summary
- Fixed handling of empty GHUI_KEY_ALIAS environment variable 
- Now properly defaults to 'ghui' when the environment variable is empty or whitespace-only
- This should resolve the 'Keystore was tampered with' errors in the release workflow

## Context
The release workflow was failing with:
```
Failed to read key *** from store "/home/runner/work/Android/Android/app/keystore.jks": Keystore was tampered with, or password was incorrect
```

This was happening because when GHUI_KEY_ALIAS is set but empty in GitHub secrets, the previous code would use an empty string as the key alias instead of the default 'ghui'.

## Test Plan
- [ ] Release workflow should successfully build signed APKs and bundles
- [ ] The key alias should default to 'ghui' when not specified

🤖 Generated with [Claude Code](https://claude.ai/code)