### PR TITLE
fix: Simplify signing configuration to only use environment variables

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,23 +22,16 @@ android {
         }
 
         release {
-            // Release signing is only configured when keystore is provided via CI/CD
-            // The keystore will be decoded from KEYSTORE_BASE64 and placed temporarily
-            if (file("keystore.jks").exists() && project.hasProperty("GHUI_KEYSTORE_PASSWORD") && project.hasProperty("GHUI_KEY_PASSWORD")) {
-                storeFile file("keystore.jks")
-                storePassword GHUI_KEYSTORE_PASSWORD
-                keyAlias project.hasProperty("GHUI_KEY_ALIAS") ? GHUI_KEY_ALIAS : "ghui"
-                keyPassword GHUI_KEY_PASSWORD
-            } else if (System.getenv("GHUI_KEYSTORE_PASSWORD") != null && System.getenv("GHUI_KEY_PASSWORD") != null) {
-                // CI/CD environment but keystore file might not exist yet
-                // This prevents the build from failing during configuration phase
+            // Release signing requires environment variables to be set
+            // The keystore will be decoded from KEYSTORE_BASE64 in CI/CD
+            if (System.getenv("GHUI_KEYSTORE_PASSWORD") != null && System.getenv("GHUI_KEY_PASSWORD") != null) {
                 storeFile file("keystore.jks")
                 storePassword System.getenv("GHUI_KEYSTORE_PASSWORD")
                 keyAlias (System.getenv("GHUI_KEY_ALIAS") ?: "").trim().isEmpty() ? "ghui" : System.getenv("GHUI_KEY_ALIAS")
                 keyPassword System.getenv("GHUI_KEY_PASSWORD")
             } else {
-                // For local builds without proper signing setup, throw an error
-                throw new GradleException("Release builds require signing configuration. Please provide GHUI_KEYSTORE_PASSWORD and GHUI_KEY_PASSWORD.")
+                // Release builds require proper environment variables
+                throw new GradleException("Release builds require signing configuration. Please set GHUI_KEYSTORE_PASSWORD and GHUI_KEY_PASSWORD environment variables.")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Simplified the signing configuration to only use environment variables
- Removed gradle property checks that were complicating the logic
- Always expect keystore to be decoded from KEYSTORE_BASE64 in CI/CD

## Context
The previous configuration had multiple conditions that were causing confusion:
1. Checking for file existence
2. Checking for gradle properties (which aren't used in CI)
3. Checking for environment variables

This simplification ensures that:
- Release builds always require environment variables
- The keystore.jks file is always expected to be created from base64 in CI/CD
- No more confusion about which path the code takes

## Test Plan
- [ ] Release workflow should successfully build signed APKs and bundles
- [ ] Error message is clear when environment variables are missing

🤖 Generated with [Claude Code](https://claude.ai/code)