### PR TITLE
fix: Use GitHub secret names directly without GHUI_ prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,23 @@ jobs:
       run: |
         echo "$KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
         
+    - name: Debug keystore info
+      if: ${{ vars.ENABLE_SIGNING == 'true' }}
+      run: |
+        echo "Keystore file exists: $([ -f app/keystore.jks ] && echo 'Yes' || echo 'No')"
+        echo "Keystore size: $([ -f app/keystore.jks ] && ls -la app/keystore.jks | awk '{print $5}' || echo 'N/A')"
+        echo "Key alias configured: ${{ secrets.KEY_ALIAS != '' && 'Yes' || 'No' }}"
+        
     - name: Build release APK
       env:
-        GHUI_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-        GHUI_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        GHUI_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
         KEYSTORE_PATH: ${{ vars.ENABLE_SIGNING == 'true' && 'keystore.jks' || '' }}
       run: |
         if [ "${{ vars.ENABLE_SIGNING }}" = "true" ] && [ -f "app/keystore.jks" ]; then
           echo "Building signed release APK"
+          echo "Using key alias: ${KEY_ALIAS:-ghui}"
           ./gradlew assembleRelease --stacktrace
         else
           echo "Building unsigned release APK"
@@ -129,9 +137,9 @@ jobs:
         
     - name: Build release bundle
       env:
-        GHUI_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-        GHUI_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        GHUI_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
         KEYSTORE_PATH: ${{ vars.ENABLE_SIGNING == 'true' && 'keystore.jks' || '' }}
       run: |
         if [ "${{ vars.ENABLE_SIGNING }}" = "true" ] && [ -f "app/keystore.jks" ]; then

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,14 +24,14 @@ android {
         release {
             // Release signing requires environment variables to be set
             // The keystore will be decoded from KEYSTORE_BASE64 in CI/CD
-            if (System.getenv("GHUI_KEYSTORE_PASSWORD") != null && System.getenv("GHUI_KEY_PASSWORD") != null) {
+            if (System.getenv("KEYSTORE_PASSWORD") != null && System.getenv("KEY_PASSWORD") != null) {
                 storeFile file("keystore.jks")
-                storePassword System.getenv("GHUI_KEYSTORE_PASSWORD")
-                keyAlias (System.getenv("GHUI_KEY_ALIAS") ?: "").trim().isEmpty() ? "ghui" : System.getenv("GHUI_KEY_ALIAS")
-                keyPassword System.getenv("GHUI_KEY_PASSWORD")
+                storePassword System.getenv("KEYSTORE_PASSWORD")
+                keyAlias System.getenv("KEY_ALIAS")?.trim() ?: "ghui"
+                keyPassword System.getenv("KEY_PASSWORD")
             } else {
                 // Release builds require proper environment variables
-                throw new GradleException("Release builds require signing configuration. Please set GHUI_KEYSTORE_PASSWORD and GHUI_KEY_PASSWORD environment variables.")
+                throw new GradleException("Release builds require signing configuration. Please set KEYSTORE_PASSWORD and KEY_PASSWORD environment variables.")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Updated build.gradle to use the exact GitHub secret names (KEYSTORE_PASSWORD, KEY_PASSWORD, KEY_ALIAS)
- Removed the GHUI_ prefix mapping in the workflow that was causing confusion
- Fixed null handling for KEY_ALIAS using Groovy's safe navigation operator

## Context
The release workflow was failing because:
1. The build.gradle was expecting environment variables with GHUI_ prefix
2. The workflow was mapping secrets to GHUI_ prefixed names
3. This extra mapping layer was unnecessary and causing issues

Now the build.gradle directly uses the same names as the GitHub secrets:
- `KEYSTORE_PASSWORD`
- `KEY_PASSWORD`
- `KEY_ALIAS`

## Changes
- build.gradle: Changed from `System.getenv("GHUI_KEYSTORE_PASSWORD")` to `System.getenv("KEYSTORE_PASSWORD")` etc.
- release.yml: Removed the GHUI_ prefix mapping, now passes secrets directly
- Fixed NullPointerException when KEY_ALIAS is not set

## Test Plan
- [ ] Release workflow should successfully build signed APKs and bundles
- [ ] No more NullPointerException errors
- [ ] Signing should work with the configured GitHub secrets

🤖 Generated with [Claude Code](https://claude.ai/code)