### PR TITLE
chore: Update dependabot schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      day: 1
       time: "09:00"
     open-pull-requests-limit: 10
     groups:
@@ -47,7 +47,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      day: 1
       time: "09:00"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Update dependabot schedule to run monthly instead of weekly
- Applies to both gradle and github-actions dependency updates

## Changes
- Changed interval from "weekly" to "monthly"
- Updates will run on the 1st of each month at 09:00
- No changes to grouping or other configurations

## Motivation
Reduce the frequency of dependency update PRs to make them more manageable.

🤖 Generated with [Claude Code](https://claude.ai/code)