### PR TITLE
fix: Remove invalid 'day' field from dependabot monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: 1
       time: "09:00"
     open-pull-requests-limit: 10
     groups:
@@ -48,6 +47,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: 1
       time: "09:00"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Remove invalid 'day' field from monthly schedule configuration
- Fixes dependabot.yml validation errors in PRs

## Problem
The dependabot.yml validation was failing in PRs with the error shown in the `.github/dependabot.yml` check. The issue was that we had `day: 1` in the monthly schedule configuration, but this field is not valid for monthly intervals.

## Solution
Removed the `day: 1` field from both:
- gradle package ecosystem schedule
- github-actions package ecosystem schedule

The monthly schedule will now run on the first day of each month by default at 09:00.

## Test plan
- [ ] This PR should have all CI checks passing
- [ ] After merging, existing dependabot PRs should no longer show the dependabot.yml validation error

🤖 Generated with [Claude Code](https://claude.ai/code)