### PR TITLE
fix the total topic count with thousand separators

### DIFF
--- a/app/src/main/java/me/ghui/v2er/network/bean/NodeTopicInfo.java
+++ b/app/src/main/java/me/ghui/v2er/network/bean/NodeTopicInfo.java
@@ -21,7 +21,7 @@ import me.ghui.v2er.util.Utils;
 public class NodeTopicInfo extends BaseInfo {
 
     @Pick("span.topic-count strong")
-    private int total;
+    public String totalStr;
     @Pick(value = "a[href*=favorite/] ", attr = Attrs.HREF)
     private String favoriteLink;
     @Pick("div.box div.cell:has(table)")
@@ -32,7 +32,11 @@ public class NodeTopicInfo extends BaseInfo {
     }
 
     public int getTotal() {
-        return total;
+        try {
+            return Integer.parseInt(totalStr.replaceAll("[^0-9]", ""));
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
     public List<Item> getItems() {
@@ -66,7 +70,7 @@ public class NodeTopicInfo extends BaseInfo {
     public String toString() {
         return "NodeTopicInfo{" +
                 "favoriteLink=" + favoriteLink +
-                ",total=" + total +
+                ",total=" + totalStr +
                 ", items=" + items +
                 '}';
     }


### PR DESCRIPTION
问题：打开大部分节点时候空白，出现 Unknown Error(-1)

主题总数使用千分位，直接转换int会报错，
e.g. 
<span class="topic-count">主题总数 <strong>137,647</strong></span>

Caused by: java.lang.NumberFormatException: For input string: "137,647"
	at java.lang.Integer.parseInt(Integer.java:781)
	at java.lang.Integer.valueOf(Integer.java:1108)
	at me.ghui.fruit.bind.PickAdapters.parseElement(PickAdapters.java:103)
	at me.ghui.fruit.bind.PickAdapters.access$000(PickAdapters.java:17)
	at me.ghui.fruit.bind.PickAdapters$2.read(PickAdapters.java:33)
	at me.ghui.fruit.bind.PickAdapters$2.read(PickAdapters.java:30)
	at me.ghui.fruit.bind.ReflectivePickAdapterFactory$1.read(ReflectivePickAdapterFactory.java:111)
	at me.ghui.fruit.bind.ReflectivePickAdapterFactory$Adapter.read(ReflectivePickAdapterFactory.java:64)
	at me.ghui.fruit.Fruit.fromHtml(Fruit.java:61)
	at me.ghui.fruit.Fruit.fromHtml(Fruit.java:49)
	at me.ghui.fruit.converter.retrofit.FruitResponseBodyConverter.convert(FruitResponseBodyConverter.java:28)
	at me.ghui.fruit.converter.retrofit.FruitResponseBodyConverter.convert(FruitResponseBodyConverter.java:15)
	at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:246)
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:207)
	at retrofit2.adapter.rxjava2.CallExecuteObservable.subscribeActual(CallExecuteObservable.java:46)
	at io.reactivex.Observable.subscribe(Observable.java:12284)
	at retrofit2.adapter.rxjava2.BodyObservable.subscribeActual(BodyObservable.java:35)
	at io.reactivex.Observable.subscribe(Observable.java:12284)
	at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run(ObservableSubscribeOn.java:96)
	at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:608)
	at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
	at java.lang.Thread.run(Thread.java:1119)