### PR TITLE
fix crash when not found; It might be better to remove the try-catch block

### DIFF
--- a/app/src/main/java/me/ghui/v2er/network/APIService.java
+++ b/app/src/main/java/me/ghui/v2er/network/APIService.java
@@ -5,7 +5,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -26,6 +25,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
+import okio.Buffer;
 import okio.BufferedSource;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
@@ -126,7 +126,7 @@ public class APIService {
                 return new Response.Builder()
                         .protocol(Protocol.HTTP_1_1)
                         .code(404)
-                        .message("Exeception when execute chain.proceed request")
+                        .message("Exception when execute chain.proceed request")
                         .body(new ResponseBody() {
                             @Nullable
                             @Override
@@ -141,7 +141,7 @@ public class APIService {
 
                             @Override
                             public BufferedSource source() {
-                                return null;
+                                return new Buffer();
                             }
                         })
                         .request(request).build();


### PR DESCRIPTION
fix crash.

`java.lang.NullPointerException: Parameter specified as non-null is null: method okhttp3.internal._UtilCommonKt.closeQuietly, parameter <this>
	at okhttp3.internal._UtilCommonKt.closeQuietly(Unknown Source:2)
	at okhttp3.ResponseBody.close(ResponseBody.kt:195)
	at okhttp3.Response.close(Response.kt:343)
	at okhttp3.internal._UtilCommonKt.closeQuietly(-UtilCommon.kt:284)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:210)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:530)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1251)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:668)
	at java.lang.Thread.run(Thread.java:1012)`

![Screenshot_2025-07-30-10-37-30-144_com miui thirdappassistant~2](https://github.com/user-attachments/assets/217a23b9-e363-4f58-8308-39bcbada6f0f)


