### PR TITLE
Fix build issues by removing unused Condom library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,7 +120,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:okhttp3-integration:4.16.0'
     implementation 'pub.devrel:easypermissions:3.0.0'
     implementation 'org.greenrobot:eventbus:3.3.1'
-    implementation 'com.github.oasisfeng:condom:2.5.0'
+    // Temporarily disabled due to JitPack issues
+    // implementation 'com.github.oasisfeng:condom:2.5.0'
     implementation 'org.slf4j:slf4j-nop:2.0.17'
     implementation 'androidx.core:core-splashscreen:1.0.1'
 }

--- a/app/src/main/java/me/ghui/v2er/general/App.java
+++ b/app/src/main/java/me/ghui/v2er/general/App.java
@@ -4,7 +4,6 @@ import android.app.Application;
 
 import androidx.annotation.Nullable;
 
-import com.oasisfeng.condom.CondomContext;
 import com.orhanobut.logger.AndroidLogAdapter;
 import com.orhanobut.logger.FormatStrategy;
 import com.orhanobut.logger.Logger;


### PR DESCRIPTION
## Summary
- Removed unused CondomContext import from App.java
- Commented out Condom library dependency that was causing build failures
- This ensures the app can be built and deployed to Google Play

## Context
Google Play requires apps to target Android 15 (API level 35) or higher by August 31, 2025. Our app already targets API level 36, but build was failing due to JitPack connectivity issues with the Condom library dependency.

## Changes
- Removed unused `CondomContext` import from `App.java` 
- Commented out the Condom library dependency in `app/build.gradle`
- The library was imported but never actually used in the codebase

## Test Plan
- [x] Build debug APK successfully
- [x] Verified APK targets SDK version 36
- [ ] Test on Android 15/16 devices or emulators
- [ ] Build and test release APK

## Impact
No functional impact - the Condom library was not being used. The app maintains full functionality while fixing the build issues.

🤖 Generated with [Claude Code](https://claude.ai/code)