### PR TITLE
feat: add ReTrace mapping file upload to Google Play Console

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: release-bundle
-        path: app/build/outputs/bundle/**/*.aab
+        path: |
+          app/build/outputs/bundle/**/*.aab
+          app/build/outputs/mapping/release/mapping.txt
         retention-days: 30
 
   release:
@@ -290,6 +292,15 @@ jobs:
           echo "No debug symbols found"
         fi
         
+        # Look for ProGuard/R8 mapping file
+        MAPPING_PATH=$(find release-artifacts -name "mapping.txt" 2>/dev/null | head -1)
+        if [ -n "$MAPPING_PATH" ]; then
+          echo "mapping_path=$MAPPING_PATH" >> $GITHUB_OUTPUT
+          echo "Found ReTrace mapping file at: $MAPPING_PATH"
+        else
+          echo "No ReTrace mapping file found"
+        fi
+        
     - name: Determine release track and status
       id: release-config
       run: |
@@ -331,6 +342,7 @@ jobs:
         track: ${{ steps.release-config.outputs.track }}
         status: ${{ steps.release-config.outputs.status }}
         debugSymbols: ${{ steps.find-files.outputs.symbols_path }}
+        mappingFile: ${{ steps.find-files.outputs.mapping_path }}
         whatsNewDirectory: whatsnew/
       continue-on-error: true
       id: upload-with-symbols
@@ -344,6 +356,7 @@ jobs:
         releaseFiles: ${{ steps.find-files.outputs.aab_path }}
         track: ${{ steps.release-config.outputs.track }}
         status: ${{ steps.release-config.outputs.status }}
+        mappingFile: ${{ steps.find-files.outputs.mapping_path }}
         whatsNewDirectory: whatsnew/
         
     - name: Play Store Upload Summary


### PR DESCRIPTION
## Summary
Enable automatic upload of ProGuard/R8 mapping files to Google Play Console for crash deobfuscation.

## Changes Made

### Release Workflow (`.github/workflows/release.yml`)
- ✅ **Bundle Artifact**: Include `mapping.txt` in release-bundle artifact alongside AAB file
- ✅ **File Detection**: Add mapping file discovery in `Find bundle and symbols` step
- ✅ **Upload Configuration**: Add `mappingFile` parameter to both Google Play upload steps

### Workflow Logic
```yaml
# Package mapping file with AAB
path: |
  app/build/outputs/bundle/**/*.aab
  app/build/outputs/mapping/release/mapping.txt

# Detect mapping file
MAPPING_PATH=$(find release-artifacts -name "mapping.txt" 2>/dev/null | head -1)

# Upload to Google Play Console
mappingFile: ${{ steps.find-files.outputs.mapping_path }}
```

## Benefits
🎯 **Crash Deobfuscation**: Stack traces in Google Play Console will show original class/method names  
📊 **Better Debugging**: Production crashes can be properly diagnosed with unobfuscated stack traces  
🔄 **Automatic Process**: No manual mapping file upload required  
✅ **Backwards Compatible**: Works whether mapping file is present or not  

## Impact
- **Next Release**: Will automatically upload ReTrace mapping file to Google Play Console
- **Crash Reports**: Production crash stack traces will be properly deobfuscated 
- **Security**: App remains obfuscated while maintaining debuggability

## Dependencies
This PR builds on the minification changes in PR #91:
- Requires R8 minification to be enabled (`minifyEnabled true`)
- Depends on mapping.txt file generation during build process

🤖 Generated with [Claude Code](https://claude.ai/code)