### PR TITLE
fix: correct job dependency in download-signed-apk workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,7 +385,7 @@ jobs:
 
   download-signed-apk:
     name: Download Google Play Signed APK
-    needs: [prepare, upload-play-store]
+    needs: [prepare, play-store-upload]
     runs-on: ubuntu-latest
     if: success()
     


### PR DESCRIPTION
## Summary
- Fix dependency from 'upload-play-store' to 'play-store-upload' in the download-signed-apk job
- This resolves the workflow failure: "Job depends on unknown job" error

## Issue
The v2.3.2 release failed because the `download-signed-apk` job referenced a non-existent job name `upload-play-store`. The correct job name is `play-store-upload`.

## Fix
Changed the `needs` dependency from:
```yaml
needs: [prepare, upload-play-store]
```
to:
```yaml  
needs: [prepare, play-store-upload]
```

## Test plan
- [x] Workflow syntax validation
- [ ] Re-trigger v2.3.2 release after merge
- [ ] Verify complete pipeline including Google Play signed APK download

🤖 Generated with [Claude Code](https://claude.ai/code)