### PR TITLE
chore: bump version to 2.3.6.1

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -1,7 +1,7 @@
 ext {
     app = [
-            versionCode: 236,
-            versionName: "2.3.6"
+            versionCode: 237,
+            versionName: "2.3.6.1"
     ]
     android = [
             supportVersion: '26.1.0'


### PR DESCRIPTION
## Summary
- Bump version to 2.3.6.1
- Version code: 237
- Includes the gallery crash fix from PR #110

## Changes
- Updated version in `config.gradle`

## Release Notes
This patch release includes:
- Fix for gallery crash when clicking null images in replies

🤖 Generated with [Claude Code](https://claude.ai/code)