### PR TITLE
fix: correct parsing of consecutive sign-in days

### DIFF
--- a/app/src/main/java/me/ghui/v2er/network/bean/DailyInfo.java
+++ b/app/src/main/java/me/ghui/v2er/network/bean/DailyInfo.java
@@ -26,6 +26,22 @@ public class DailyInfo extends BaseInfo {
     }
 
     public String getCheckinDays() {
+        if (Check.isEmpty(continuousLoginDayStr)) return "";
+
+        // Extract consecutive days from strings like:
+        // "您已连续登录 123 天"
+        // "ghui 已连续签到 12 天 2024/12/25"
+        // "用户161290已连续签到 5 天"
+
+        // Use regex to find number followed by "天" (days)
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(\\d+)\\s*天");
+        java.util.regex.Matcher matcher = pattern.matcher(continuousLoginDayStr);
+
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        // Fallback to extracting all digits if pattern not found
         return Utils.extractDigits(continuousLoginDayStr);
     }
 

--- a/app/src/test/java/me/ghui/v2er/network/bean/DailyInfoTest.java
+++ b/app/src/test/java/me/ghui/v2er/network/bean/DailyInfoTest.java
@@ -54,13 +54,14 @@ public class DailyInfoTest {
 
         @Override
         public String getCheckinDays() {
-            // Use reflection or make the field package-private in actual implementation
+            // Use reflection to set the field for testing purposes
             try {
                 java.lang.reflect.Field field = me.ghui.v2er.network.bean.DailyInfo.class.getDeclaredField("continuousLoginDayStr");
                 field.setAccessible(true);
                 field.set(this, continuousLoginDayStr);
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                // Fail the test explicitly if reflection fails
+                throw new RuntimeException("Failed to access continuousLoginDayStr via reflection: " + e.getMessage(), e);
             }
             return super.getCheckinDays();
         }

--- a/app/src/test/java/me/ghui/v2er/network/bean/DailyInfoTest.java
+++ b/app/src/test/java/me/ghui/v2er/network/bean/DailyInfoTest.java
@@ -1,0 +1,68 @@
+package me.ghui.v2er.network.bean;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DailyInfoTest {
+
+    @Test
+    public void testGetCheckinDays_withValidFormat() {
+        // Test case 1: Standard format
+        DailyInfo dailyInfo = new DailyInfo();
+        dailyInfo.continuousLoginDayStr = "您已连续登录 123 天";
+        assertEquals("123", dailyInfo.getCheckinDays());
+    }
+
+    @Test
+    public void testGetCheckinDays_withDateInString() {
+        // Test case 2: String contains date and other numbers
+        DailyInfo dailyInfo = new DailyInfo();
+        // Simulate the actual problematic string that might appear
+        dailyInfo.continuousLoginDayStr = "ghui 已连续签到 12 天 2024/12/25";
+        String result = dailyInfo.getCheckinDays();
+        // After fix, it should correctly extract "12"
+        assertEquals("12", result);
+    }
+
+    @Test
+    public void testGetCheckinDays_withUserId() {
+        // Test case 3: String contains user ID and days
+        DailyInfo dailyInfo = new DailyInfo();
+        dailyInfo.continuousLoginDayStr = "用户161290已连续签到 5 天";
+        String result = dailyInfo.getCheckinDays();
+        // After fix, it should correctly extract "5"
+        assertEquals("5", result);
+    }
+
+    @Test
+    public void testGetCheckinDays_withNull() {
+        DailyInfo dailyInfo = new DailyInfo();
+        dailyInfo.continuousLoginDayStr = null;
+        assertEquals("", dailyInfo.getCheckinDays());
+    }
+
+    @Test
+    public void testGetCheckinDays_withEmpty() {
+        DailyInfo dailyInfo = new DailyInfo();
+        dailyInfo.continuousLoginDayStr = "";
+        assertEquals("", dailyInfo.getCheckinDays());
+    }
+
+    // Make continuousLoginDayStr accessible for testing
+    private static class DailyInfo extends me.ghui.v2er.network.bean.DailyInfo {
+        String continuousLoginDayStr;
+
+        @Override
+        public String getCheckinDays() {
+            // Use reflection or make the field package-private in actual implementation
+            try {
+                java.lang.reflect.Field field = me.ghui.v2er.network.bean.DailyInfo.class.getDeclaredField("continuousLoginDayStr");
+                field.setAccessible(true);
+                field.set(this, continuousLoginDayStr);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return super.getCheckinDays();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed incorrect parsing of consecutive sign-in days that was extracting all digits from the HTML string
- Now correctly extracts only the number before "天" (days) using regex pattern matching
- Added comprehensive unit tests for various edge cases

## Problem
The `getCheckinDays()` method was using `Utils.extractDigits()` which extracts ALL digits from the string. When the HTML contained user IDs, dates, or other numbers, they would all be concatenated, resulting in displays like "21612902025091812天" instead of the actual consecutive days count.

## Solution
- Use regex pattern `(\\d+)\\s*天` to specifically match numbers followed by "天"
- Maintain backward compatibility with fallback to `extractDigits()` for unexpected formats
- Added unit tests covering various scenarios including strings with dates and user IDs

## Test plan
- [x] Run unit tests: `./gradlew testDebugUnitTest`
- [x] Build debug APK: `./gradlew assembleDebug`
- [x] Test on physical device (Pixel 8)
- [x] Verify sign-in days display correctly in the app

🤖 Generated with [Claude Code](https://claude.ai/code)