### PR TITLE
refactor: improve node topic count parsing with better error handling

### DIFF
--- a/app/src/main/java/me/ghui/v2er/network/bean/NodeTopicInfo.java
+++ b/app/src/main/java/me/ghui/v2er/network/bean/NodeTopicInfo.java
@@ -11,6 +11,7 @@ import me.ghui.v2er.util.Check;
 import me.ghui.v2er.network.Constants;
 import me.ghui.v2er.util.UriUtils;
 import me.ghui.v2er.util.Utils;
+import me.ghui.v2er.util.L;
 
 /**
  * Created by ghui on 27/05/2017.
@@ -21,7 +22,7 @@ import me.ghui.v2er.util.Utils;
 public class NodeTopicInfo extends BaseInfo {
 
     @Pick("span.topic-count strong")
-    public String totalStr;
+    private String totalCountRaw; // Raw topic count string from HTML (may contain thousand separators)
     @Pick(value = "a[href*=favorite/] ", attr = Attrs.HREF)
     private String favoriteLink;
     @Pick("div.box div.cell:has(table)")
@@ -32,9 +33,16 @@ public class NodeTopicInfo extends BaseInfo {
     }
 
     public int getTotal() {
+        if (totalCountRaw == null || totalCountRaw.isEmpty()) {
+            return 0;
+        }
+
         try {
-            return Integer.parseInt(totalStr.replaceAll("[^0-9]", ""));
-        } catch (Exception e) {
+            // Remove thousand separators (commas) and any other non-numeric characters
+            String cleanedNumber = totalCountRaw.replaceAll("[^0-9]", "");
+            return Integer.parseInt(cleanedNumber);
+        } catch (NumberFormatException e) {
+            L.e("Failed to parse topic count: " + totalCountRaw + ", error: " + e.getMessage());
             return 0;
         }
     }
@@ -70,7 +78,7 @@ public class NodeTopicInfo extends BaseInfo {
     public String toString() {
         return "NodeTopicInfo{" +
                 "favoriteLink=" + favoriteLink +
-                ",total=" + totalStr +
+                ",total=" + totalCountRaw +
                 ", items=" + items +
                 '}';
     }


### PR DESCRIPTION
## Summary
- Follow-up improvements to PR #82 based on GitHub Copilot review feedback
- Enhances the node topic count parsing implementation with better error handling and code clarity

## Changes
- **Renamed variable**: `totalStr` → `totalCountRaw` for better clarity about its purpose
- **Added null/empty check**: Validates the raw string before attempting to parse
- **Improved exception handling**: Uses specific `NumberFormatException` instead of generic `Exception`
- **Added error logging**: Logs parsing failures with the problematic value for debugging
- **Added descriptive comment**: Documents that the field contains raw HTML data with thousand separators

## Testing
- Tested with nodes containing large topic counts (100,000+) 
- Verified proper handling of null/empty values
- Confirmed error logging works when parsing fails

## Related
- Follows up on #82 which fixed the initial NumberFormatException issue
- Implements code review suggestions from GitHub Copilot

🤖 Generated with [Claude Code](https://claude.ai/code)