### PR TITLE
fix: resolve TextView font style persistence in RecyclerView (#120)

### DIFF
--- a/app/src/main/java/me/ghui/v2er/injector/module/MsgModule.java
+++ b/app/src/main/java/me/ghui/v2er/injector/module/MsgModule.java
@@ -47,11 +47,16 @@ public class MsgModule {
                 holder.getView(R.id.msg_content_tv);
                 if (!Check.isEmpty(reply.getContent())) {
                     holder.getView(R.id.msg_content_tv).setVisibility(View.VISIBLE);
-//                    holder.setText(R.id.msg_content_tv, reply.getContent());
+                    // Clear previous text to avoid recycling issues
+                    holder.getTextView(R.id.msg_content_tv).setText("");
+                    holder.getTextView(R.id.msg_content_tv).setMovementMethod(null);
                     RichText.from(reply.getContent())
                             .into(holder.getTextView(R.id.msg_content_tv));
                 } else {
                     holder.getView(R.id.msg_content_tv).setVisibility(View.GONE);
+                    // Clear text when hiding to avoid recycling issues
+                    holder.getTextView(R.id.msg_content_tv).setText("");
+                    holder.getTextView(R.id.msg_content_tv).setMovementMethod(null);
                 }
                 holder.setText(R.id.time_tv, reply.getTime());
             }

--- a/app/src/main/java/me/ghui/v2er/injector/module/SearchModule.java
+++ b/app/src/main/java/me/ghui/v2er/injector/module/SearchModule.java
@@ -38,6 +38,9 @@ public class SearchModule {
                 holder.setText(R.id.search_result_title_tv, hit.getSource().getTitle());
                 String footnote = hit.getSource().getCreator() + " 于 " + hit.getSource().getTime() + " 发表, " + hit.getSource().getReplies() + " 回复";
                 holder.setText(R.id.search_result_footnote_tv, footnote);
+                // Clear previous text to avoid recycling issues
+                holder.getTextView(R.id.search_result_content_tv).setText("");
+                holder.getTextView(R.id.search_result_content_tv).setMovementMethod(null);
                 RichText.from(hit.getSource().getContent())
                         .supportUrlClick(false)
                         .into(holder.getTextView(R.id.search_result_content_tv));

--- a/app/src/main/java/me/ghui/v2er/injector/module/UserHomeModule.java
+++ b/app/src/main/java/me/ghui/v2er/injector/module/UserHomeModule.java
@@ -85,6 +85,9 @@ public class UserHomeModule {
             public void convert(ViewHolder holder, UserPageInfo.Item item, int position) {
                 UserPageInfo.ReplyItem replyItem = (UserPageInfo.ReplyItem) item;
                 holder.setText(R.id.reply_title_tv, replyItem.getTitle());
+                // Clear previous text to avoid recycling issues
+                holder.getTextView(R.id.reply_content_tv).setText("");
+                holder.getTextView(R.id.reply_content_tv).setMovementMethod(null);
                 RichText.from(replyItem.getContent())
                         .widthDelta(43)
                         .into(holder.getTextView(R.id.reply_content_tv));

--- a/app/src/main/java/me/ghui/v2er/module/topic/TopicReplyItemDelegate.java
+++ b/app/src/main/java/me/ghui/v2er/module/topic/TopicReplyItemDelegate.java
@@ -75,7 +75,9 @@ public class TopicReplyItemDelegate extends ItemViewDelegate<TopicInfo.Item> {
         contentView.setTextSize(TypedValue.COMPLEX_UNIT_PX, FontSizeUtil.getContentSize());
         if (Check.notEmpty(replyInfo.getReplyContent())) {
             contentView.setVisibility(View.VISIBLE);
-            contentView = holder.getView(R.id.content_tv);
+            // Clear previous text and spans to avoid style persistence
+            contentView.setText("");
+            contentView.setMovementMethod(null);
             String replyContent = replyInfo.getReplyContent();
             OnMemberLinkClickListener clickListener = null;
             if (replyContent.contains("/member/")) {
@@ -87,6 +89,9 @@ public class TopicReplyItemDelegate extends ItemViewDelegate<TopicInfo.Item> {
                     .into(contentView);
         } else {
             contentView.setVisibility(View.GONE);
+            // Clear text when hiding to avoid recycling issues
+            contentView.setText("");
+            contentView.setMovementMethod(null);
         }
         holder.setText(R.id.floor_tv, replyInfo.getFloor());
     }


### PR DESCRIPTION
## Summary
- Fixed font style persistence issue when scrolling through topic replies and other RecyclerView-based lists
- Clears TextView content and movement method before applying RichText to prevent style carryover during view recycling
- Addresses issue #120 where users reported text formatting changes randomly when scrolling

## Problem
When scrolling through posts in the topic detail page, the font styles (bold, italic, links) would randomly appear on text that shouldn't have them. This was caused by RecyclerView's view recycling mechanism where previously styled TextViews weren't properly cleared before reuse.

## Solution
Added explicit clearing of TextView content and movement method before applying new RichText content across all adapters that use RichText rendering:
- **TopicReplyItemDelegate**: Clear reply content TextView before rendering
- **SearchModule**: Clear search result content before applying RichText  
- **UserHomeModule**: Clear reply content TextView in user profile
- **MsgModule**: Clear notification content TextView

## Testing
- ✅ Built debug APK successfully
- ✅ Lint checks passed
- ✅ No compilation errors

## Fixes
Closes #120

🤖 Generated with [Claude Code](https://claude.ai/code)