### PR TITLE
fix: 修复在Pixel 10 Pro上ToolBar显示错误

### DIFF
--- a/app/src/main/java/me/ghui/v2er/module/home/MainActivity.java
+++ b/app/src/main/java/me/ghui/v2er/module/home/MainActivity.java
@@ -163,6 +163,7 @@ public class MainActivity extends BaseActivity implements View.OnClickListener,
         isAlive = true;
         configToolBar();
 
+        Utils.setPaddingForStatusBar(mNavigationView);
         mNavigationView.setItemIconTintList(null);
         mNavHeaderView = mNavigationView.getHeaderView(0);
         mAvatarImg = mNavHeaderView.findViewById(R.id.avatar_img);
@@ -248,7 +249,7 @@ public class MainActivity extends BaseActivity implements View.OnClickListener,
                 int statusBarHeight = Utils.getStatusBarHeight();
 
                 // When toolbar is scrolled up and would be under status bar, hide it
-                if (Math.abs(verticalOffset) >= toolbarHeight - statusBarHeight) {
+                if (verticalOffset > 0 && Math.abs(verticalOffset) >= toolbarHeight - statusBarHeight) {
                     mToolbar.setVisibility(View.INVISIBLE);
                 } else {
                     mToolbar.setVisibility(View.VISIBLE);


### PR DESCRIPTION
可能是因为Pixel 10 Pro上前置摄像头很高，所以设备的状态栏高度也很高，理论上不应该有什么兼容问题，但是在MainActivity中有一个自动隐藏的[逻辑](https://github.com/v2er-app/Android/blob/main/app/src/main/java/me/ghui/v2er/module/home/MainActivity.java#L244-L256)（在Pixel 10 Pro上测试，滚动没有生效，可能有另外的原因），根据日志打印的情况，verticalOffset的值一直为0，但是toolbarHeight的值为125，statusBarHeight为151，判定走了隐藏ToolBar的逻辑，最终导致设备上不显示ToolBar，但是会显示ToolBar的区域，造成界面出现显示错误。
mNavigationView 组件也有相同的情况，但是那是因为没有设置Padding/MarginTop的原因。

相关截图：
<img width="287" height="640" alt="图片" src="https://github.com/user-attachments/assets/5abb73b0-fe42-49d6-9a41-5616ef10ed3a" />
<img width="287" height="640" alt="Screenshot_20250928-000955" src="https://github.com/user-attachments/assets/4d705bf5-3e05-4081-ad7a-93add3345406" />


相关打印代码：
```
Log.i("TAG", "onOffsetChanged: " + verticalOffset + ", " + toolbarHeight + ", " + statusBarHeight);
```
<img width="340" height="74" alt="图片" src="https://github.com/user-attachments/assets/c8255c00-2648-4a6f-b655-ac82feedd16d" />
